### PR TITLE
Update windows target to include 32 bit builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "win": {
       "target": [
           {
-            "target": 'nsis',
+            "target": "nsis",
             "arch": [
-              'x64', 'ia32'
+              "x64", "ia32"
             ]
           }
         ]

--- a/package.json
+++ b/package.json
@@ -56,8 +56,15 @@
         "dmg"
       ]
     },
-    "nsis": {
-      "perMachine": true
+    "win": {
+      "target": [
+          {
+            "target": 'nsis',
+            "arch": [
+              'x64', 'ia32'
+            ]
+          }
+        ]
     },
     "linux": {
       "target": [


### PR DESCRIPTION
Re our email, I think this would be the proper config for a 32 + 64 bit build on windows.  I haven't validated it yet, so lets make sure it builds before we merge.