### PR TITLE
Fix Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
       - icnsutils
       - graphicsmagick
       - xz-utils
+      - build-essential
+      - libudev-dev
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi
   - export JOBS=max

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
           "target": "AppImage",
           "arch": [
             "x64",
-            "ia32",
             "armv7l",
             "arm64"
           ]


### PR DESCRIPTION
This

- Installs the two build time dependencies required by node-usb
- Only builds a 64 bit linux target.

I can't get this module to build for 32 bit systems after an hour of trying.  The only idea I have left is to fire up another parallel build VM that is 32 bit itself and try with that, however I would recomend that a 64 bit only target would be simpler to support, unless of course there are buisness customers who need 32 bit, as rare as those environments are these days.