### PR TITLE
eval job in default namespace to allow require

### DIFF
--- a/core/job.js
+++ b/core/job.js
@@ -340,7 +340,10 @@ class Job{
 
     static start_and_monitor_dexter_job(job_src){
         let base_id_before_new_def = Job.job_id_base
-        try { window.eval(job_src) }
+        try { 
+            //window.eval(job_src) 
+            eval(job_src) //evail into default namespace to allow require in source
+        }
         catch(err) {dde_error("While evaling the job definition to send to Dexter,<br/>" +
                               "got error: " + err.message)
         }


### PR DESCRIPTION
Hopefully this will resolve the require issue in job engine jobs. It seems to work in 3.5.2. 

My concern is what unknown issues this change might cause. If we knew /why/ this was done as window.eval instead of just eval, we could asses this better.