### PR TITLE
Adding that you have to eval changes to dde_init

### DIFF
--- a/doc/guide.html
+++ b/doc/guide.html
@@ -195,7 +195,8 @@
     that is automatically inserted into the file dde_apps/dde_init.js is fine.
     However, in that file you may need to modify the ip_address and port number
     of Dexter. The default ip_address is <code>"192.168.1.142"</code> The port number
-    is typically <code>"50000"</code>.
+    is typically <code>"50000"</code>. Be sure to (Eval)uate the file or restart DDE so
+    your changes will have effect. 
 </details>
 
 <details id="configure_dexter_id" class="doc_details"><summary>Configure Dexter</summary>


### PR DESCRIPTION
Because someone spent some time trying to connect to a robot with a different IP and missed that step.