### PR TITLE
Improve error message to help find the source

### DIFF
--- a/src/job_engine/core/gcode.js
+++ b/src/job_engine/core/gcode.js
@@ -34,7 +34,7 @@ globalThis.Gcode = class Gcode{
                     dde_error("In Gcode.line_to_do_list_item got invalid non_upper case first letter of: " + op)
                 }
                 let val = token.substring(1)
-                val = parseFloat(val)
+                if (val.length > 0) val = parseFloat(val); else val = 0;
                 if (Number.isNaN(val)) {
                     dde_error("In Gcode.line_to_do_list_item on line "+line_tokens+" after token "+token+" got non-number value of: " + val);
                 }

--- a/src/job_engine/core/gcode.js
+++ b/src/job_engine/core/gcode.js
@@ -36,7 +36,7 @@ globalThis.Gcode = class Gcode{
                 let val = token.substring(1)
                 val = parseFloat(val)
                 if (Number.isNaN(val)) {
-                    dde_error("In Gcode.line_to_do_list_item got non-number value of: " + val)
+                    dde_error("In Gcode.line_to_do_list_item on line "+line_tokens+" after token "+token+" got non-number value of: " + val);
                 }
                 this.state[op] = val
                 let handler_function_name = "handle_" + op


### PR DESCRIPTION
Just make it possible to track down the source of a g-code error. 

There are two issues I've found:
- A version of G28 which normally just finds home, now can have a sort of flag after it to specify that the bed should or shouldn't be leveled. But it can have no value after it. e.g. `G28 W` so there is no number after the W which causes an "NaN" error in the current code. The line `val = parseFloat(val)` needs to be changed to something like:
`if (val.length > 0) val = parseFloat(val); else val = 0`
- A version of M117 which is setting the message on the LCD. But it's not putting quotes around the string, so the text of the message ends up looking like an invalid code. It may be that we need to add an M option handler. Or the call to the hadler needs to include a pass by reference so a custom M handler in the user code can erase the rest of the line. 